### PR TITLE
Create organization README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,8 @@
+# Welcome to Jazzband 🎸🚀
+
+Jazzband is a collaborative community to share the responsibility of
+maintaining Python-based projects. It gives maintainers and contributors
+the ability to “play in the same band” instead of being forced into “artist”
+and “audience” roles.
+
+Get started by visiting [https://jazzband.co](https://jazzband.co)!


### PR DESCRIPTION
This will be a front-page README for the Jazzband GitHub page. Original reason was to display a link for GSoC candidates to find a Kanban board of potential projects that can be accepted for GSoC.